### PR TITLE
[FIX] Fixes #1 Exclude node_modules from rollup - watch config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -49,5 +49,8 @@ export default [
       !isProduction && livereload(),
       isProduction && terser.terser(),
     ],
+    watch: {
+      exclude: ["node_modules/**"],
+    },
   },
 ];


### PR DESCRIPTION
Added node_modules to the exclude list of watched files for Rollup.js